### PR TITLE
fixed call to stop stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ stream.on('channels/web',function(tweet){
 //});
 
 setTimeout(function(){
-    stream.close();//closes the stream connected to Twitter
+    stream.stop();//closes the stream connected to Twitter
 	console.log('>stream closed after 100 seconds');
 },100000);
 ```


### PR DESCRIPTION
I just changed the call in the documentation, because calling "close()" threw an error for me. After some looking around in the source code, I saw it's supposed to be "stop()". This works :)