### PR TITLE
Pass full text when tweet is truncated

### DIFF
--- a/lib/StreamChannels.js
+++ b/lib/StreamChannels.js
@@ -272,7 +272,8 @@ var helpers = {
     var keywordsFound = [], tmpKeywords;
     
     //prepare the lowerCased strings to full text search in the tweet object
-    lowerCasedSearch.push(tweet.text.toLowerCase());
+    var tweetText = tweet.truncated ? tweet.extended_tweet.full_text : tweet.text;
+    lowerCasedSearch.push(tweetText.toLowerCase());
     if(tweet.user && tweet.user.screen_name){
       lowerCasedSearch.push(tweet.user.screen_name.toLowerCase());
     }


### PR DESCRIPTION
With twitter's increased in character limits, twitter truncates text and adds in the extended_tweet object. I have changed search to use full_text when tweet is truncated.